### PR TITLE
(magit-popup-set-variable): Don't bother refreshing if unchanged

### DIFF
--- a/magit-popup.el
+++ b/magit-popup.el
@@ -879,11 +879,16 @@ TYPE is one of `:action', `:sequence-action', `:switch', or
 
 (defun magit-popup-set-variable
     (variable choices &optional default other)
-  (magit-set (--if-let (magit-git-string "config" "--local" variable)
-                 (cadr (member it choices))
-               (car choices))
-             variable)
-  (magit-refresh)
+  (let* ((curval (lambda ()
+                   (or (magit-git-string "config" variable)
+                       default)))
+         (old (funcall curval)))
+    (magit-set (--if-let (magit-git-string "config" "--local" variable)
+                   (cadr (member it choices))
+                 (car choices))
+               variable)
+    (unless (equal old (funcall curval))
+      (magit-refresh)))
   (message "%s %s" variable
            (magit-popup-format-variable-1 variable choices default other)))
 


### PR DESCRIPTION
When working with a large buffer (e.g., a status buffer with a large diff), calling `magit-refresh' can be an expensive operation.

Now, we'll only call `magit-refresh' when a variable's overall value has actually changed (not just when its local configuration is set).