### PR TITLE
Allow a popup to be redefined

### DIFF
--- a/magit-popup.el
+++ b/magit-popup.el
@@ -612,8 +612,9 @@ usually specified in that order):
        (defun ,name (&optional arg) ,doc
          (interactive "P")
          (magit-invoke-popup ',name ,mode arg))
-       (defvar ,name
-         (list :variable ',opt ,@args))
+       (unless (boundp ',name)
+         (defvar ,name))
+       (setq ,name (list :variable ',opt ,@args))
        (magit-define-popup-keys-deferred ',name)
        ,@(when opt
            `((defcustom ,opt (plist-get ,name :default-arguments)


### PR DESCRIPTION
Trying to change a popup menu at runtime requires to unintern the
existing variable, due to defvar. As far as I known, there is no
reason to avoid updating the value if the variable already exists.